### PR TITLE
Fix issues with prefix searches

### DIFF
--- a/search.py
+++ b/search.py
@@ -145,11 +145,12 @@ def run_query(query: Query, results_file: Optional[Path], args: Namespace) -> In
         if len(intersection) == 0:
             logging.debug(f"Empty intersection, quitting early")
             break
-    for _, results in search_results[1:]:
-        results.values.close()
 
     if intersection != search_results[0][1]:
         clean_up(initial_results_file, [".ia", ".ia.cfg"])
+    for _, results in search_results:
+        if results != intersection:
+            results.values.close()
     return intersection
 
 

--- a/search.py
+++ b/search.py
@@ -126,10 +126,6 @@ def run_query(query: Query, results_file: Optional[Path], args: Namespace) -> In
             logging.debug(f"     -- subsumed: {subq}")
             continue
         if any(lit.is_prefix() for lit in subq.literals):
-            lengths = sorted([len(res[1]) for res in search_results])
-            if len(results) > 0.1 * lengths[1]:
-                logging.debug(f"     -- skipping prefix: {subq}")
-                continue
             results = collect_and_sort_prefix(results, tmp_prefix)
             
         intersection_type = intersection.merge_update(

--- a/search.py
+++ b/search.py
@@ -67,10 +67,7 @@ def run_outer(query: Query, results_file: Optional[Path], args: Namespace) -> In
                 pass
         else: 
             union = partial_results
-        try: 
-            clean_up(tmp_results, [".ia", ".ia.cfg"])
-        except FileNotFoundError: 
-            pass
+        clean_up(tmp_results, [".ia", ".ia.cfg"])
     assert union is not None
     return union
 
@@ -138,10 +135,8 @@ def run_query(query: Query, results_file: Optional[Path], args: Namespace) -> In
         )
         logging.info(f" /\\{intersection_type[0].upper()} {subq!s:{maxwidth}} = {intersection}")
         used_queries.append(subq)
-        try: 
-        except FileNotFoundError: 
-            pass
         clean_up(temporary_results_file, [".ia", ".ia.cfg"])
+
         if len(intersection) == 0:
             logging.debug(f"Empty intersection, quitting early")
             break

--- a/search.py
+++ b/search.py
@@ -100,8 +100,10 @@ def run_query(query: Query, results_file: Optional[Path], args: Namespace) -> In
         search_results.append((subq, results))
         logging.info(f"     {subq!s:{maxwidth}} = {results}")
 
+    initial_results_file = CACHE_DIR / 'initial_sorted_results'
+    temporary_results_file = CACHE_DIR / 'sorted_results'
+
     search_results.sort(key=lambda r: len(r[-1]))
-    tmp_prefix = CACHE_DIR / "tmp_prefix"
     if search_results[0][0].is_negative() or any(lit.is_prefix() for lit in search_results[0][0].literals):
         try:
             first_ok = [q.is_negative() or any(lit.is_prefix() for lit in q.literals) for q,_ in search_results].index(False)
@@ -109,7 +111,7 @@ def run_query(query: Query, results_file: Optional[Path], args: Namespace) -> In
         except ValueError:
             first_ok = [any(lit.is_prefix() for lit in q.literals) for q,_ in search_results].index(True)
             first_result = search_results[first_ok]
-            first_result = (first_result[0], collect_and_sort_prefix(first_result[1], tmp_prefix))
+            first_result = (first_result[0], collect_and_sort_prefix(first_result[1], initial_results_file))
         del search_results[first_ok]
         search_results.insert(0, first_result)
     logging.debug("Intersection order:")
@@ -126,7 +128,7 @@ def run_query(query: Query, results_file: Optional[Path], args: Namespace) -> In
             logging.debug(f"     -- subsumed: {subq}")
             continue
         if any(lit.is_prefix() for lit in subq.literals):
-            results = collect_and_sort_prefix(results, tmp_prefix)
+            results = collect_and_sort_prefix(results, temporary_results_file)
             
         intersection_type = intersection.merge_update(
             results,
@@ -137,14 +139,17 @@ def run_query(query: Query, results_file: Optional[Path], args: Namespace) -> In
         logging.info(f" /\\{intersection_type[0].upper()} {subq!s:{maxwidth}} = {intersection}")
         used_queries.append(subq)
         try: 
-            clean_up(tmp_prefix, [".ia", ".ia.cfg"])
         except FileNotFoundError: 
             pass
+        clean_up(temporary_results_file, [".ia", ".ia.cfg"])
         if len(intersection) == 0:
             logging.debug(f"Empty intersection, quitting early")
             break
     for _, results in search_results[1:]:
         results.values.close()
+
+    if intersection != search_results[0][1]:
+        clean_up(initial_results_file, [".ia", ".ia.cfg"])
     return intersection
 
 

--- a/tests/corpus_test.py
+++ b/tests/corpus_test.py
@@ -1,0 +1,153 @@
+import unittest
+from unittest.mock import MagicMock
+from pathlib import Path
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+from typing import List
+
+from build_indexes import yield_templates
+from corpus import Corpus
+from index import Index
+from index_builder import build_index
+from query import Query
+from search import search_corpus
+
+
+class CorpusTest(unittest.TestCase):
+    declared_corpus_features: List[str]
+    declared_corpus_data: List[List[str]]
+
+    root_dir: TemporaryDirectory[str]
+    corpus_ready: bool
+
+    corpus_name: str = 'corpus'
+
+    def setUp(self):
+        super().setUp()
+        self.args = MagicMock()
+        self.args.pivot_selector = 'first'
+        self.args.cutoff = None
+        self.args.filter = None
+
+        self.declared_corpus_features = []
+        self.declared_corpus_data = []
+        self.root_dir = TemporaryDirectory()
+        self.corpus_ready = False
+
+    def tearDown(self):
+        super().tearDown()
+        self.root_dir.cleanup()
+
+    def corpus_features(self, *features: str):
+        """
+        Define which attributes are present in the corpus.
+        """
+        self.declared_corpus_features = [feat for feat in features]
+        self.declared_corpus_data = [[] for _ in self.declared_corpus_features]
+
+    def corpus_data(self, *data_columns: List[str]) -> int:
+        """
+        Add data to the corpus.
+
+        Data is added as *f* lists, where *f* is the number of defined features.
+        Every list must have the same length.
+
+        Returns the corpus position to which the data was inserted.
+        """
+        self.assertNotEqual(len(self.declared_corpus_features), 0,
+                            msg='Cannot add data to corpus without defined features.')
+
+        number_of_features = len(self.declared_corpus_features)
+        number_of_columns = len(data_columns)
+        self.assertEqual(number_of_features, number_of_columns,
+                         msg=f'Expected {number_of_features} columns of data but {number_of_columns} were provided')
+
+        first_column_length = len(data_columns[0])
+        inserted_at_position = len(self.declared_corpus_data[0])
+        for index, attribute in enumerate(self.declared_corpus_features):
+            row = data_columns[index]
+            self.assertEqual(first_column_length, len(row),
+                             msg=f'Attribute {attribute} expected {first_column_length} values but got {len(row)}')
+
+            self.declared_corpus_data[index].extend(data_columns[index])
+        return inserted_at_position
+
+    def get_corpus(self) -> Corpus:
+        return Corpus(Path(self.root_dir.name) / CorpusTest.corpus_name)
+
+    def _prepare_corpus_if_not_prepared(self):
+        if self.corpus_ready:
+            return
+
+        reversed_features = [f'{feature}_rev' for feature in self.declared_corpus_features]
+        self.args.features = self.declared_corpus_features + reversed_features
+        self.args.no_sentence_breaks = True
+        self.args.max_dist = 0
+
+        with NamedTemporaryFile(suffix='.csv', delete_on_close=False) as source_file:
+            self._write_source_file(source_file)
+
+            dir_corpus = Path(self.root_dir.name) / (CorpusTest.corpus_name + Corpus.dir_suffix)
+            dir_corpus.mkdir(exist_ok=True)
+            Corpus.build(dir_corpus, Path(source_file.name))
+
+            dir_index = Path(self.root_dir.name) / (CorpusTest.corpus_name + Index.dir_suffix)
+            dir_index.mkdir(exist_ok=True)
+            with self.get_corpus() as corpus:
+                for template in yield_templates(corpus, self.args):
+                    build_index(corpus, template, self.args)
+        self.corpus_ready = True
+
+    def _write_source_file(self, file):
+        header = '\t'.join(self.declared_corpus_features) + '\n'
+        file.write(header.encode())
+        for token in range(len(self.declared_corpus_data[0])):
+            attributes = range(len(self.declared_corpus_features))
+            row = '\t'.join([self.declared_corpus_data[attribute][token] for attribute in attributes]) + '\n'
+            file.write(row.encode())
+        file.flush()
+
+    def execute_test_query(self, corpus, query):
+        query = Query.parse(corpus, query, self.args.no_sentence_breaks)
+        return search_corpus(corpus, query, self.args)
+
+    def assert_search_finds(self, query: str, needle: int, offset: int = 0):
+        """
+        Asserts that the query result set is exactly the provided *needle*.
+
+        If an offset is provided, the result set must be *needle* + *offset*.
+        """
+        self.assert_search_finds_all(query, needle, offset=offset)
+
+    def assert_search_finds_all(self, query, *needles: int, offset: int = 0):
+        """
+        Asserts that the query result set is exactly the set of provided *needles*.
+
+        If an offset is provided it is added to every needle that must be included in the result set.
+        """
+        self._prepare_corpus_if_not_prepared()
+        with self.get_corpus() as corpus:
+            result = self.execute_test_query(corpus, query)
+            self.assertEqual(len(result), len(needles),
+                             msg=f'Query should find {len(needles)} result(s) but found {len(result)}.')
+            for needle in needles:
+                self.assertIn(needle + offset, result,
+                              msg=f'Query failed to return expected token at position {needle + offset}.')
+
+    def assert_search_has_attributes(self, query: str, **attributes):
+        """
+        Asserts that the given key-value-pairs match for every token in the result set.
+        """
+        self._prepare_corpus_if_not_prepared()
+        with self.get_corpus() as corpus:
+            result = self.execute_test_query(corpus, query)
+
+            if len(result) == 0:
+                self.fail('No results found for query.')
+
+            for position, element in enumerate(result):
+                for feature, expected_value in attributes.items():
+                    strings = corpus.tokens[feature.encode()]
+                    actual_value = strings.interned_string(strings[element])
+
+                    self.assertEqual(expected_value, actual_value,
+                                     msg=f'Feature {feature} on result #{position} should be {expected_value} but is {actual_value}.')

--- a/tests/corpus_test.py
+++ b/tests/corpus_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import MagicMock
 from pathlib import Path
@@ -17,6 +18,7 @@ class CorpusTest(unittest.TestCase):
     declared_corpus_data: List[List[str]]
 
     root_dir: TemporaryDirectory[str]
+    corpus_source_file: NamedTemporaryFile
     corpus_ready: bool
 
     corpus_name: str = 'corpus'
@@ -31,11 +33,13 @@ class CorpusTest(unittest.TestCase):
         self.declared_corpus_features = []
         self.declared_corpus_data = []
         self.root_dir = TemporaryDirectory()
+        self.corpus_source_file = NamedTemporaryFile(suffix='.csv', delete=False)
         self.corpus_ready = False
 
     def tearDown(self):
         super().tearDown()
         self.root_dir.cleanup()
+        os.remove(self.corpus_source_file.name)
 
     def corpus_features(self, *features: str):
         """
@@ -83,7 +87,7 @@ class CorpusTest(unittest.TestCase):
         self.args.no_sentence_breaks = True
         self.args.max_dist = 0
 
-        with NamedTemporaryFile(suffix='.csv', delete_on_close=False) as source_file:
+        with self.corpus_source_file as source_file:
             self._write_source_file(source_file)
 
             dir_corpus = Path(self.root_dir.name) / (CorpusTest.corpus_name + Corpus.dir_suffix)

--- a/tests/test_affix_search.py
+++ b/tests/test_affix_search.py
@@ -1,3 +1,5 @@
+import unittest
+
 from tests.corpus_test import CorpusTest
 from unittest import skip
 
@@ -69,3 +71,6 @@ class MyTestCase(CorpusTest):
             '[word="d.*"] [word="a.*"]',
             2, 5
         )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_affix_search.py
+++ b/tests/test_affix_search.py
@@ -1,0 +1,71 @@
+from tests.corpus_test import CorpusTest
+from unittest import skip
+
+class MyTestCase(CorpusTest):
+
+    def test_search_one_attribute(self):
+        self.corpus_features('word')
+        self.corpus_data(
+            ['aba', 'abba', 'abbba', 'b', 'abbbba']
+        )
+
+        self.assert_search_finds(
+            '[word="a.*"] [word="b"]',
+            2
+        )
+
+    def test_search_prefix_regex(self):
+        self.corpus_features('word')
+        self.corpus_data(
+            ['a', 'aa', 'aaa', 'ba', 'b']
+        )
+
+        self.assert_search_finds_all(
+            '[word=".*a"]',
+            0, 1, 2, 3
+        )
+
+    def test_search_suffix_regex(self):
+        self.corpus_features('word')
+        self.corpus_data(
+            ['a', 'aa', 'aaa', 'ab', 'b']
+        )
+
+        self.assert_search_finds_all(
+            '[word="a.*"]',
+            0, 1, 2, 3
+        )
+
+    def test_search_infix_regex(self):
+        self.corpus_features('word')
+        self.corpus_data(
+            ['aa', 'aaa', 'aba', 'ab', 'b']
+        )
+
+        self.assert_search_finds_all(
+            '[word="a.*a"]',
+            0, 1, 2
+        )
+
+    @skip('Matching any value using regex is not yet supported.')
+    def test_search_matchall_regex(self):
+        self.corpus_features('word')
+        self.corpus_data(
+            ['a', 'b', 'c', 'd', 'e']
+        )
+
+        self.assert_search_finds_all(
+            '[word=".*"]',
+            0, 1, 2, 3, 4
+        )
+
+    def test_query_with_two_regex(self):
+        self.corpus_features('word')
+        self.corpus_data(
+            ['ma', 'de', 'de', 'ax', 'bca', 'da', 'a', 'a', 'exas']
+        )
+
+        self.assert_search_finds_all(
+            '[word="d.*"] [word="a.*"]',
+            2, 5
+        )

--- a/tests/test_basic_search.py
+++ b/tests/test_basic_search.py
@@ -1,0 +1,73 @@
+from tests.corpus_test import CorpusTest
+
+
+class MyTestCase(CorpusTest):
+
+    def test_search_one_attribute(self):
+        self.corpus_features('word', 'pos')
+        needle = self.corpus_data(
+            ['This', 'is', 'a', 'test'],
+            ['PRON', 'AUX', 'DET', 'NOUN']
+        )
+
+        for offset, word in enumerate(['This', 'is', 'a', 'test']):
+            self.assert_search_finds(
+                f'[word="{word}"]',
+                needle,
+                offset=offset
+            )
+
+    def test_search_all_attributes(self):
+        self.corpus_features('a', 'b', 'c', 'd')
+        self.corpus_data(
+            ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8'],
+            ['b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7', 'b8'],
+            ['c1', 'c2', 'c3', 'c4', 'c5', 'c6', 'c7', 'c8'],
+            ['d1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8'],
+        )
+
+        self.assert_search_has_attributes(
+            '[a="a1"]',
+            a='a1',
+            b='b1',
+            c='c1',
+            d='d1'
+        )
+        self.assert_search_has_attributes(
+            '[b="b3"]',
+            a='a3',
+            b='b3',
+            c='c3',
+            d='d3'
+        )
+        self.assert_search_has_attributes(
+            '[c="c5"]',
+            a='a5',
+            b='b5',
+            c='c5',
+            d='d5'
+        )
+        self.assert_search_has_attributes(
+            '[d="d7"]',
+            a='a7',
+            b='b7',
+            c='c7',
+            d='d7'
+        )
+
+    def test_search_finds_token_sequence(self):
+        self.corpus_features('w')
+        self.corpus_data(
+            [str(i) for i in range(10)],
+        )
+        needle = self.corpus_data(
+            ['needle' for _ in range(4)]
+        )
+        self.corpus_data(
+            [str(i) for i in range(10)],
+        )
+
+        self.assert_search_finds(
+            '[w="needle"] [w="needle"] [w="needle"] [w="needle"]',
+            needle
+        )

--- a/tests/test_basic_search.py
+++ b/tests/test_basic_search.py
@@ -1,3 +1,5 @@
+import unittest
+
 from tests.corpus_test import CorpusTest
 
 
@@ -71,3 +73,6 @@ class MyTestCase(CorpusTest):
             '[w="needle"] [w="needle"] [w="needle"] [w="needle"]',
             needle
         )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/util.py
+++ b/util.py
@@ -63,8 +63,12 @@ def uncompressed_suffix(path: Path) -> str:
         return path.suffix
 
 def clean_up(path: Path, suffixes: list[str]):
+    """For every given suffix, the given path with the suffix appended is removed from the file system."""
     for suffix in suffixes:
-        add_suffix(path, suffix).unlink()
+        try:
+            add_suffix(path, suffix).unlink()
+        except FileNotFoundError:
+            pass
 
 
 ###############################################################################


### PR DESCRIPTION
Small set of fixes for prefix search functionality. Fixes #16.

The following changes are included:
- A small test suite containing integration tests for corpus search functionality
- Prefix queries matching more than 10% of the corpus are no longer skipped
- Prefix queries with multiple tokens no longer return the wrong duplicated features (see #16) 