### PR TITLE
Correctly close underlying resources when building indexes

### DIFF
--- a/corpus_reader.py
+++ b/corpus_reader.py
@@ -1,6 +1,7 @@
-
 from pathlib import Path
 from collections.abc import Iterator, Callable
+from abc import ABC, abstractmethod
+from typing import Iterable
 
 from util import Feature, FValue, EMPTY, SENTENCE, START, check_feature
 from util import CompressedFileReader, uncompressed_suffix
@@ -9,76 +10,125 @@ from util import progress_bar, ProgressBar
 Header = list[Feature]
 Token = list[FValue]
 Sentence = list[Token]
-CorpusReader = tuple[Header, Iterator[Sentence]]
-
-CORPUS_READERS: dict[str, Callable[[Path, str], CorpusReader]] = {}
 
 
-def corpus_reader(path: Path, description: str, sentence_feature: bool = True, 
+class CorpusReader(ABC):
+    @property
+    @abstractmethod
+    def header(self) -> Header:
+        pass
+
+    @abstractmethod
+    def sentences(self) -> Iterator[Sentence]:
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        self.close()
+
+
+def corpus_reader(path: Path, description: str, sentence_feature: bool = True,
                   reversed_features: bool = True) -> CorpusReader:
     suffix = uncompressed_suffix(path)
-    try: 
+    try:
         reader = CORPUS_READERS[suffix]
     except KeyError:
         raise ValueError(f"Cannot find a corpus reader for file type: {suffix}")
-    return augment_reader(reader(path, description), sentence_feature, reversed_features)
+    reader_instance = reader(path, description)
+    return AugmentedReader(reader_instance, sentence_feature, reversed_features)
 
 
-def augment_reader(reader: CorpusReader, sentence_feature: bool, reversed_features: bool) -> CorpusReader:
-    header, sentences = reader
-    header = list(header)  # Make a copy of header, so it won't interfere with the sentence iterator
-    if reversed_features:
-        header += [Feature(feature + b'_rev') for feature in header]
-    if sentence_feature:
-        header.append(SENTENCE)
-    return header, augment_sentences(sentences, sentence_feature, reversed_features)
+class AugmentedReader(CorpusReader):
+    wrapped: CorpusReader
+    sentence_feature: bool
+    reversed_features: bool
+
+    def __init__(self, reader: CorpusReader, sentence_feature: bool, reversed_features: bool):
+        self.wrapped = reader
+        self.sentence_feature = sentence_feature
+        self.reversed_features = reversed_features
+
+        self._header = reader.header
+        if self.reversed_features:
+            revd = [Feature(feature + b'_rev') for feature in self._header]
+            self._header.extend(revd)
+        if self.sentence_feature:
+            self._header.append(SENTENCE)
+
+    @property
+    def header(self) -> Header:
+        return self._header
+
+    def sentences(self) -> Iterator[Sentence]:
+        for sentence in self.wrapped.sentences():
+            for token in sentence:
+                if self.reversed_features:
+                    token += [FValue(val.decode()[::-1].encode()) for val in token]
+                if self.sentence_feature:
+                    token.append(EMPTY)
+            if self.sentence_feature:
+                sentence[0][-1] = START
+            yield sentence
+
+    def close(self):
+        self.wrapped.close()
 
 
-def augment_sentences(sentence_iterator: Iterator[Sentence], sentence_feature: bool,
-                      reversed_features: bool) -> Iterator[Sentence]:
-    for sentence in sentence_iterator:
-        for token in sentence:
-            if reversed_features:
-                token += [FValue(val.decode()[::-1].encode()) for val in token]
-            if sentence_feature:
-                token.append(EMPTY)
-        if sentence_feature:
-            sentence[0][-1] = START
-        yield sentence
-            
+class CSVReader(CorpusReader):
+    _corpus: CompressedFileReader
+    _header: Header
+    _description: str
 
+    def __init__(self, path: Path, description: str):
+        self._corpus = CompressedFileReader(path)
+        self._description = description
 
-def csv_reader(path: Path, description: str) -> CorpusReader:
-    corpus = CompressedFileReader(path)
-    # the first line in the CSV should be a header with the names of each column (=features)
-    header: Header = list(map(Feature, corpus.reader.readline().strip().split(b'\t')))
-    for feat in header: check_feature(feat)
-    n_feats = len(header)
+        header_line = self._corpus.reader.readline()
+        self._header = [Feature(f) for f in CSVReader.split_line(header_line.strip())]
+        for feat in self._header: check_feature(feat)
+        self._n_feats = len(self._header)
 
-    def sentence_iterator() -> Iterator[Sentence]:
+    @staticmethod
+    def split_line(line: bytes) -> Iterable[bytes]:
+        return line.split(b'\t')
+
+    @property
+    def header(self) -> Header:
+        return self._header
+
+    def sentences(self) -> Iterator[Sentence]:
         pbar: ProgressBar[None]
-        with progress_bar(total=corpus.file_size(), desc=description) as pbar:
+        with progress_bar(total=self._corpus.file_size(), desc=self._description) as pbar:
             sentence: Sentence = []
-            for n, line in enumerate(corpus.reader, 2):
+            for n, line in enumerate(self._corpus.reader, 2):
                 line = line.strip()
                 if line.startswith(b'# '):
-                    pbar.update(corpus.file_position() - pbar.n)
-                    if sentence: 
+                    pbar.update(self._corpus.file_position() - pbar.n)
+                    if sentence:
                         yield sentence
                         sentence = []
                 elif line:
-                    token = list(map(FValue, line.split(b'\t')))
-                    if len(token) < n_feats:
-                        token += [EMPTY] * (n_feats - len(token))
-                    assert len(token) == n_feats, f"Line {n}, too many columns (>{n_feats}): {token}"
+                    token = [FValue(v) for v in CSVReader.split_line(line)]
+                    if len(token) < self._n_feats:
+                        token += [EMPTY] * (self._n_feats - len(token))
+                    assert len(token) == self._n_feats, f"Line {n}, too many columns (>{self._n_feats}): {token}"
                     sentence.append(token)
-            pbar.update(corpus.file_position() - pbar.n)
-            if sentence: 
+            pbar.update(self._corpus.file_position() - pbar.n)
+            if sentence:
                 yield sentence
 
-    return header, sentence_iterator()
+    def close(self):
+        self._corpus.close()
 
 
+CORPUS_READERS: dict[str, Callable[[Path, str], CorpusReader]] = {}
+
+csv_reader = lambda path, description: CSVReader(path, description)
 CORPUS_READERS['.csv'] = csv_reader
 CORPUS_READERS['.tsv'] = csv_reader
-


### PR DESCRIPTION
As the integration tests introduced with #17 showed, some resources were not closed correctly when building indexes for a corpus. This caused messages like the following printed as part of the unclosed resource detection that's part of python's testing framework:

> `korpsearch/corpus_reader.py:39: ResourceWarning: unclosed file <_io.BufferedReader name='/var/folders/jf/m2x9llfx56xccz26rz6ydxd00000gn/T/tmpg2w_jdvv.csv'>`

This PR introduces 2 changes to address this issue:
1. Classes are introduced managing the state of underlying resources when building indexes
2. A call to close the resources managed by an instance of these classes is made after indexes have been build.

As an additional bonus, it should now be quite easy to support other formats for corpora. Simply implement another subclass of `CorpusReader` and register it for the adequate file extension in the `CORPUS_READERS` dictionary.