### PR TITLE
Complex expressions in queries

### DIFF
--- a/docs/korpsearch.js
+++ b/docs/korpsearch.js
@@ -1,5 +1,5 @@
 
-const API_DOMAIN = "https://korpsearch.cse.chalmers.se:8000/";
+const API_DOMAIN = "http://localhost:8000/";
 const LOCALE = "en-US";
 
 const ELEMS = {

--- a/expressions.py
+++ b/expressions.py
@@ -1,0 +1,51 @@
+import re
+from pyeda.inter import And, Or, Not
+from pyeda.boolalg.expr import exprvar
+
+def tokenize(expression):
+    """ Tokenizes a Boolean expression into variables, operators, and parentheses. """
+    tokens = re.findall(r'[A-Za-z]+|[&|!()]', expression)
+    return tokens
+
+def parse_boolean_expr(tokens):
+    """ Parses a tokenized Boolean expression and constructs a pyeda expression. """
+    def parse_factor():
+        """ Parses a single factor: variable, negation, or subexpression. """
+        token = tokens.pop(0)
+        if token.isalpha():  # Variable (e.g., 'a', 'b')
+            return exprvar(token)
+        elif token == "!":  # NOT operator
+            return Not(parse_factor())
+        elif token == "(":  # Subexpression
+            expr = parse_or_expr()
+            if tokens and tokens[0] == ")":
+                tokens.pop(0)  # Consume closing parenthesis
+            return expr
+        else:
+            raise ValueError(f"Unexpected token: {token}")
+
+    def parse_and_expr():
+        """ Parses an AND-expression, flattening chains like a & b & c into And(a, b, c). """
+        factors = [parse_factor()]
+        while tokens and (tokens[0] == "&" or tokens[0] == "("):
+            if tokens[0] == "(": # Implicit "&" operator
+                factors.append(parse_or_expr())
+            else:
+                tokens.pop(0)  # Consume "&"
+                factors.append(parse_factor())
+        return factors[0] if len(factors) == 1 else And(*factors)
+
+    def parse_or_expr():
+        """ Parses an OR-expression, flattening chains like a | b | c into Or(a, b, c). """
+        terms = [parse_and_expr()]
+        while tokens and tokens[0] == "|":
+            tokens.pop(0)  # Consume "|"
+            terms.append(parse_and_expr())
+        return terms[0] if len(terms) == 1 else Or(*terms)
+
+    return parse_or_expr()
+
+def evaluate_boolean_expr(expression):
+    """ Tokenizes and parses a Boolean expression into a pyeda expression. """
+    tokens = tokenize(expression)
+    return parse_boolean_expr(tokens)

--- a/expressions.py
+++ b/expressions.py
@@ -1,10 +1,10 @@
 import re
-from pyeda.inter import And, Or, Not
+from pyeda.inter import And, Or, Not, Xor
 from pyeda.boolalg.expr import exprvar
 
 def tokenize(expression):
     """ Tokenizes a Boolean expression into variables, operators, and parentheses. """
-    tokens = re.findall(r'[A-Za-z]+|[&|!()]', expression)
+    tokens = re.findall(r'[A-Za-z]+|[&|!^()]', expression)
     return tokens
 
 def parse_boolean_expr(tokens):
@@ -35,12 +35,20 @@ def parse_boolean_expr(tokens):
                 factors.append(parse_factor())
         return factors[0] if len(factors) == 1 else And(*factors)
 
+    def parse_xor_expr():
+        """ Parses an XOR-expression, flattening chains like a ^ b ^ c into Xor(a, b, c). """
+        terms = [parse_and_expr()]
+        while tokens and tokens[0] == "^":
+            tokens.pop(0)  # Consume "^"
+            terms.append(parse_and_expr())
+        return terms[0] if len(terms) == 1 else Xor(*terms)
+
     def parse_or_expr():
         """ Parses an OR-expression, flattening chains like a | b | c into Or(a, b, c). """
-        terms = [parse_and_expr()]
+        terms = [parse_xor_expr()]
         while tokens and tokens[0] == "|":
             tokens.pop(0)  # Consume "|"
-            terms.append(parse_and_expr())
+            terms.append(parse_xor_expr())
         return terms[0] if len(terms) == 1 else Or(*terms)
 
     return parse_or_expr()

--- a/index.py
+++ b/index.py
@@ -52,6 +52,12 @@ class KnownLiteral:
         value = self.corpus.tokens[self.feature][pos + self.offset]
         return (value == self.value) != self.negative
 
+    def alter_offset(self, offset: int) -> 'KnownLiteral':
+        return KnownLiteral(self.negative, offset, self.feature, self.value, self.value2, self.corpus)
+    
+    def alter_negation(self, negative: bool) -> 'KnownLiteral':
+        return KnownLiteral(negative, self.offset, self.feature, self.value, self.value2, self.corpus)
+
     @staticmethod
     def parse(corpus: Corpus, litstr: str) -> 'KnownLiteral':
         try:
@@ -133,8 +139,8 @@ class Template:
             assert len(self.template) > 0,                             f"Empty template"
             assert self.min_offset() == 0,                             f"Minimum offset must be 0"
             assert all(lit.negative for lit in self.literals),         f"Positive template literal(s)"
-        except AssertionError:
-            raise ValueError(f"Invalid template: {self}")
+        except AssertionError as e:
+            raise ValueError(f"Invalid template: {self} -- {e}")
 
     def offsets(self) -> set[int]:
         return {lit.offset for lit in self.template + self.literals}

--- a/query.py
+++ b/query.py
@@ -340,11 +340,10 @@ class Query:
                     negative = (negated == '!')
 
                     # If the previous character was not a symbol, add an implicit AND.
-                    if len(expressionString) > 0 and expressionString[-1] not in ['(', '&', '|']:
-                        separator = '&'
-                    
                     if separator:
                         expressionString += separator
+                    elif len(expressionString) > 0 and expressionString[-1] not in ['(', '&', '|']:
+                        separator = '&'
                     
                     if negative:
                         expressionString += "!"

--- a/query.py
+++ b/query.py
@@ -343,7 +343,7 @@ class Query:
                     if separator:
                         expressionString += separator
                     elif len(expressionString) > 0 and expressionString[-1] not in ['(', '&', '|']:
-                        separator = '&'
+                        expressionString += '&'
                     
                     if negative:
                         expressionString += "!"

--- a/query.py
+++ b/query.py
@@ -3,11 +3,14 @@ import re
 import itertools
 from typing import Literal
 from collections.abc import Iterator, Sequence
+from string import ascii_lowercase
+
+from pyeda.inter import expr, Expression, And, Or
+from pyeda.boolalg.expr import exprvar, Complement
 
 from index import KnownLiteral, DisjunctiveGroup, TemplateLiteral, Template, Instance, mkInstance, Index
 from corpus import Corpus
 from util import Feature, FValue, SENTENCE, START
-
 
 ################################################################################
 ## Queries
@@ -43,8 +46,8 @@ class Query:
 
         # We cannot handle non-atomic querues with only negative literals
         # -A & -B == -(A v B), since we cannot handle union (yet)
-        if len(self) > 1 and self.is_negative():
-            raise ValueError(f"Cannot handle non-atomic queries with no positive literals: {self}")
+        #if len(self) > 1 and self.is_negative():
+        #    raise ValueError(f"Cannot handle non-atomic queries with no positive literals: {self}")
 
         # # This is a variant of self.query, optimised for checking a query at a corpus position:
         # self.featured_query = {f: [] for f in self.features}
@@ -54,17 +57,20 @@ class Query:
         #     )
 
         # We precompute the associated query template. It raises a ValueError if it's not valid.
-        if self.contains_disjunction():
-            self.template = None
-        elif self.is_negative():
-            self.template = Template(
-                [TemplateLiteral(lit.offset-self.min_offset(), lit.feature) for lit in self.negative_literals()],
-            )
-        else:
-            self.template = Template(
-                [TemplateLiteral(lit.offset-self.min_offset(), lit.feature) for lit in self.positive_literals()],
-                [KnownLiteral(True, lit.offset-self.min_offset(), lit.feature, lit.value, lit.value2, corpus) for lit in self.negative_literals()],
-            )
+        try:
+            if self.contains_disjunction():
+                self.template = None
+            elif self.is_negative():
+                self.template = Template(
+                    [TemplateLiteral(lit.offset-self.min_offset(), lit.feature) for lit in self.negative_literals()],
+                )
+            else:
+                self.template = Template(
+                    [TemplateLiteral(lit.offset-self.min_offset(), lit.feature) for lit in self.positive_literals()],
+                    [KnownLiteral(True, lit.offset-self.min_offset(), lit.feature, lit.value, lit.value2, corpus) for lit in self.negative_literals()],
+                )
+        except Exception as e:
+            raise ValueError(f"Invalid query: {self} ({e})") from e
 
 
     def __str__(self) -> str:
@@ -110,6 +116,12 @@ class Query:
     def expand(self) -> Iterator['Query']:
         groups = [group.literals for group in self.literals if isinstance(group, DisjunctiveGroup)]
         singles = [lit for lit in self.literals if isinstance(lit, KnownLiteral)]
+
+        if not singles:
+            for group in groups:
+                yield Query(self.corpus, group)
+            return
+
         for group in itertools.product(*groups):
             yield Query(self.corpus, singles + list(group))
 
@@ -161,9 +173,248 @@ class Query:
             return 'suffix'
         else:
             return 'regex'
+        
+    @staticmethod
+    def _expand_expression_parts(expression: str) -> list[list[str] | str]:
+        """
+        Expands: "([pos="DT"] [pos="JJ"] | [pos="PN"]) [word="katt"]"
+        to: [["[pos="DT"]", "[pos="JJ"]", "[word="katt"]"], "|", ["[pos="PN"]", "[word="katt"]"]]
+        
+        The seperator may be either "|" or "&"
+        """
+        
+    @staticmethod
+    def _evalute_literal(corpus: Corpus, offset: int, featstr: str, negated: str, valstr: str) -> list[KnownLiteral]:
+        feature = Feature(featstr.lower().encode())
+        negative = (negated == '!')
+        value_type = Query._classify_value(valstr)
+        match value_type:
+            case 'normal':
+                value = FValue(valstr.encode())
+                interned_string = corpus.intern(feature, value)
+                return [KnownLiteral(negative, offset, feature, interned_string, interned_string, corpus)]
+            case 'prefix':
+                valstr = valstr.split('.*')[0]
+                value = FValue(valstr.encode())
+                interned_range = corpus.interned_range(feature, value)
+                return [KnownLiteral(negative, offset, feature, interned_range[0], interned_range[1], corpus)]
+            case 'suffix':
+                valstr = valstr.split('.*')[-1][::-1]
+                value = FValue(valstr.encode())
+                feature = Feature(feature + b'_rev')
+                interned_range = corpus.interned_range(feature, value)
+                return [KnownLiteral(negative, offset, feature, interned_range[0], interned_range[1], corpus)]
+            case 'regex':
+                regex_matches = corpus.get_matches(feature, valstr)
+                return [KnownLiteral(negative, offset, feature, match, match, corpus) for match in regex_matches]
+        
+        raise ValueError(f"Unknown value type: {value_type!r}")
+    
+    @staticmethod
+    def _tokenize_expression(expression: str) -> list[str]:
+        """
+        Tokenize an expression like this: ([pos="DT" word#"stor"] & [pos="JJ" | pos="DT"] | [pos="PN"]) [word="katt"]
+        into a list of strings like this: ['(', '[pos="DT" word#"stor"]', '&', '[pos="JJ" | pos="DT"]', '|', '[pos="PN"]', ')', '[word="katt"]']
+        """
+        return re.findall(r'\[.*?\]|\(|\)|&|\|', expression)
+    
+    @staticmethod
+    def _variable_name_generator():
+        length = 1
+        while True:
+            for name in (''.join(chars) for chars in itertools.product(ascii_lowercase, repeat=length)):
+                yield name
+            length += 1
+        
+    @staticmethod
+    def _distribute_expression(expr: Expression) -> Expression:
+        """
+        Recursively transforms an expression by distributing over Or nodes in And expressions.
+        When distributing a factor, it renames the factor to include an index (e.g. d -> d1, d2, ...).
+        It also sorts the factors in each And alphabetically by variable name.
+        """
+        # Base case: if literal, return as is.
+        if expr.depth == 0:
+            return expr
+
+        # For And nodes: check if any child is an Or.
+        if expr.NAME == 'And':
+            # Look for the first Or child.
+            for idx, subexpr in enumerate(expr.xs):
+                if subexpr.depth > 0 and subexpr.NAME == 'Or':
+                    # We found an Or child.
+                    # Let 'others' be the factors that are not the Or child.
+                    others = expr.xs[:idx] + expr.xs[idx+1:]
+                    or_child = subexpr
+
+                    new_terms = []
+                    # For each disjunct in the Or, assign a unique index.
+                    for i, disj in enumerate(or_child.xs, start=1):
+                        # Rename each factor in 'others': if it is a literal, add the index.
+                        new_factors = []
+                        for factor in others:
+                            if factor.depth == 0:
+                                # For a literal like 'd', create a new variable 'd1', 'd2', etc.
+                                base = str(factor)
+                                new_factors.append(exprvar(f"{base}_{i}"))
+                            else:
+                                # Otherwise, leave it (or process it recursively if needed).
+                                new_factors.append(Query._distribute_expression(factor))
+                        
+                        # Process the disjunct recursively in case it contains nested expressions.
+                        processed_disj = Query._distribute_expression(disj)
+                        
+                        # If the disjunct is an And, flatten it.
+                        if processed_disj.depth > 0 and processed_disj.NAME == 'And':
+                            new_factors.extend(processed_disj.xs)
+                        else:
+                            new_factors.append(processed_disj)
+                        
+                        # Sort factors alphabetically by their string name.
+                        new_factors_sorted = sorted(new_factors, key=lambda x: str(x))
+                        
+                        # Build the new And term.
+                        new_terms.append(Query._distribute_expression(And(*new_factors_sorted)))
+                    
+                    # Return the Or of all the newly built And terms.
+                    return Or(*new_terms)
+            
+            # If no Or child was found in this And, process all children recursively.
+            return And(*(Query._distribute_expression(arg) for arg in expr.xs))
+        
+        # For Or nodes, simply process each child.
+        if expr.NAME == 'Or':
+            return Or(*(Query._distribute_expression(arg) for arg in expr.xs))
+        
+        # Fallback: return the expression unchanged.
+        return expr
 
     @staticmethod
     def parse(corpus: Corpus, querystr: str, no_sentence_breaks: bool = False) -> 'Query':
+        variable_names = Query._variable_name_generator()
+        
+        tokens = Query._tokenize_expression(querystr)
+        # Split tokens like '[pos="DT" word#"stor"]' into ['(', '[pos="DT"]', '[word#"stor"]', ')']
+        token_variables: map[str, KnownLiteral] = {}
+        expressionString = ""
+        offset = 0
+        for _, token in enumerate(tokens):
+            if token in ['(', ')', '&', '|']:
+                expressionString += token
+            else:
+                if len(expressionString) > 0 and expressionString[-1] not in ['(', '&', '|']:
+                    expressionString += '&'
+                expressionString += '('
+                for match in Query.token_regex.finditer(token):
+                    separator, featstr, negated, valstr = match.groups()
+
+                    negative = (negated == '!')
+
+                    if len(expressionString) > 0 and expressionString[-1] not in ['(', '&', '|']:
+                        separator = '&'
+                    
+                    if separator:
+                        expressionString += separator
+                    
+                    if negative:
+                        expressionString += "~"
+                        
+                    literals = Query._evalute_literal(corpus, offset, featstr, negated, valstr)
+                    
+                    if len(literals) > 1:
+                        expressionString += '('
+                    
+                    for index, literal in enumerate(literals):
+                        if index > 0:
+                            expressionString += '|'
+                        
+                        # a + number of variables
+                        variable = next(variable_names)
+                        
+                        # Add variable to list of variables
+                        token_variables[variable] = literal
+                        
+                        expressionString += variable
+                        
+                    if len(literals) > 1:
+                        expressionString += ')'
+                offset += 1
+                expressionString += ')'
+                
+        offset -= 1
+        
+        epr = expr(expressionString)
+
+        expanded = Query._distribute_expression(epr)
+        # And(d, Or(c, And(a, b))) ->
+        # Or(And(c, d1), And(a, b, d2)) ->
+        # And
+
+        # Convert expression to CNF
+        expanded = expanded.to_dnf()
+
+        variables: dict[str, KnownLiteral] = {}
+        if expanded.depth == 0:
+            is_compliment = isinstance(expanded, Complement)
+            term_name = expanded.inputs[0].name if is_compliment else expanded.name
+            variable_name = term_name.split('_')[0]
+            variables[term_name] = token_variables[variable_name].alter_offset(0).alter_negation(is_compliment)
+        else:
+            for index, term in enumerate(expanded.xs):
+                if term.depth == 0:
+                    variable_name = term.name[0]
+                    variables[term.name] = token_variables[variable_name].alter_offset(index)
+                else:
+                    for subindex, subterm in enumerate(term.xs):
+                        is_compliment = isinstance(subterm, Complement)
+                        term_name = subterm.inputs[0].name if is_compliment else subterm.name
+                        variable_name = term_name.split('_')[0]
+                        variables[term_name] = token_variables[variable_name].alter_offset(subindex).alter_negation(is_compliment)
+
+        cnf = expanded
+
+        # Assert that the two expressions are equal
+        #assert expanded.equivalent(cnf)  # -> True
+
+        # Move singler variables into the or expressions
+        # And(d, Or(a, b), Or(a, c)) -> 
+        
+        # Convert to function
+        
+        # Print the type of the expression
+        print(type(cnf))
+        
+        query: list[QueryElement] = []
+        
+        try:
+            if hasattr(cnf, 'xs'):
+                for term in cnf.xs:
+                    if isinstance(term, Complement):
+                        query.append(variables[term.inputs[0].name])
+                    if hasattr(term, 'xs'):                                   
+                        literals = tuple(variables[value.inputs[0].name if isinstance(value, Complement) else value.name] for value in term.xs)
+                        query.append(DisjunctiveGroup.create(literals))
+                    else:
+                        query.append(variables[term.name])
+            else:
+                query.append(variables[cnf.name])
+        except Exception as e:
+            raise ValueError(f"Error in query: {querystr!r}") from e
+        
+        #if not no_sentence_breaks:
+        #    svalue = corpus.intern(SENTENCE, START)
+        #    for soffset in range(1, offset):
+        #        query.append(KnownLiteral(True, soffset, SENTENCE, svalue, svalue, corpus))
+        
+        if not query:
+            raise ValueError(f"Found no matching query literals")
+        
+        assert not all(lit.negative for lit in query), "Cannot handle queries with only negative literals"
+        
+        return Query(corpus, query)
+
+    @staticmethod
+    def parse_old(corpus: Corpus, querystr: str, no_sentence_breaks: bool = False) -> 'Query':
         if not Query.fullq_regex.match(querystr):
             raise ValueError(f"Error in query: {querystr!r}")
         tokens = [tok.group() for tok in Query.query_regex.finditer(querystr)]

--- a/search.py
+++ b/search.py
@@ -278,7 +278,12 @@ def main_search(args: Namespace) -> dict[str, Any]:
             logging.info(f"Results: {results}")
 
             if start < len(results) and end >= 0:
-                query_offset = query.max_offset() + 1
+                # Find the maximum offset of the query, this has to be replaced with something else
+                # now that the results may be different sizes.
+                query_offset = 0
+                for subquery in query.expand():
+                    query_offset = max(query_offset, subquery.max_offset())
+                query_offset = query_offset + 1
                 try:
                     for match_pos in results.slice(max(0, start), end+1):
                         sentence = corpus.get_sentence_from_position(match_pos)


### PR DESCRIPTION
This pull request seeks to make the queries more useful by processing expressions as binary operators.

Queries can now produce unions of different sizes. An example using the 02M token Swedish Wikipedia corpus:
* `([word="katt"] | [word="en"] [word="hund"]) [word="som"] [word!="heter"]` produces the results: <html><body>
<!--StartFragment-->

... | result | ...
-- | -- | --
Vid sjukdom finns genomgående uppgift om kontakt med hund eller | katt som trolig smittorsak | .
Andra dekorativa element är ankarslut och flera i granit skulpterade motiv som flygande gäss , en hund med nyckel , en | katt som skjuter rygg | , en tupp och ett flygplan samt fyra uttrycksfulla ansikten i form av maskaroner .
• Hunden som är med på omslaget till Straight Outta Lynwood är bara | en hund som gick | förbi med sin ägare , som undrade vad som försiggick .

<!--EndFragment-->
</body>
</html>

Quick high level overview:
* Parse the expression into tokens.
* Expand it into `Or(And, And, ...)` form.
* Calculate the relative offsets of each group of tokens and apply negations.
* Produce a list of Literals and DisjunctiveGroups to produce the query.

This pull request introduces a dependency on `pyeda`, but this be unnecessary as very few features of the package is used.

See changes `query.py` for the updated handling of queries.

TODO:
* Test against a larger corpus to see if it produces the same results as the old query system.
* Look into if additional handling of invalid queries needs to be added.
* Make sure the offset calculations are correct.
* Display the results using proper result lengths instead of the length of the largest union.