### PR TITLE
Bugfixes: output display for queries containing only suffix expressions

### DIFF
--- a/search.py
+++ b/search.py
@@ -12,7 +12,7 @@ from pyroaring import BitMap
 from index import Index
 from corpus import Corpus
 from query import Query
-from util import add_suffix, Feature, SENTENCE, WORD, is_reversed_feature, unreverse_feature
+from util import add_suffix, Feature, SENTENCE, WORD, is_reversed_feature, get_base_feature
 
 CACHE_DIR = Path('cache')
 CACHE_DIR.mkdir(exist_ok=True)
@@ -251,10 +251,7 @@ def main_search(args: Namespace) -> dict[str, Any]:
             else:
                 # A suffix-search literal is stored against "feat_reversed" (see query.py),
                 # so map it back to "feat" here to find the right column to display.
-                query_base_features = {
-                    unreverse_feature(feat) if is_reversed_feature(feat) else feat
-                    for feat in query.features
-                }
+                query_base_features = {get_base_feature(f) for f in query.features}
                 features_to_show = [
                     feat for feat in corpus.features()
                     if feat in query_base_features

--- a/search.py
+++ b/search.py
@@ -12,7 +12,7 @@ from pyroaring import BitMap
 from index import Index
 from corpus import Corpus
 from query import Query
-from util import add_suffix, Feature, SENTENCE, WORD, is_reversed_feature
+from util import add_suffix, Feature, SENTENCE, WORD, is_reversed_feature, unreverse_feature
 
 CACHE_DIR = Path('cache')
 CACHE_DIR.mkdir(exist_ok=True)
@@ -249,9 +249,15 @@ def main_search(args: Namespace) -> dict[str, Any]:
                     if f not in corpus.features():
                         raise ValueError(f"Unknown feature: {f!r}")
             else:
+                # A suffix-search literal is stored against "feat_reversed" (see query.py),
+                # so map it back to "feat" here to find the right column to display.
+                query_base_features = {
+                    unreverse_feature(feat) if is_reversed_feature(feat) else feat
+                    for feat in query.features
+                }
                 features_to_show = [
                     feat for feat in corpus.features()
-                    if feat in query.features
+                    if feat in query_base_features
                     if args.no_sentence_breaks or feat != SENTENCE  # don't show the sentence feature
                     if not is_reversed_feature(feat)  # don't show reversed features
                 ]

--- a/util.py
+++ b/util.py
@@ -31,9 +31,9 @@ def is_reversed_feature(feature: Feature) -> bool:
 def reverse_feature(feature: Feature) -> Feature:
     return Feature(feature + b'_reversed')
 
-def unreverse_feature(feature: Feature) -> Feature:
-    assert is_reversed_feature(feature), f"Not a reversed feature: {feature!r}"
-    return Feature(feature[:-len(b'_reversed')])
+def get_base_feature(feature: Feature) -> Feature:
+    if is_reversed_feature(feature): return Feature(feature[:-len(b'_reversed')])
+    return feature
 
 def check_feature(feature: Feature) -> None:
     assert isinstance(feature, bytes), f"Feature must be a bytestring: {feature!r}"

--- a/util.py
+++ b/util.py
@@ -31,6 +31,9 @@ def is_reversed_feature(feature: Feature) -> bool:
 def reverse_feature(feature: Feature) -> Feature:
     return Feature(feature + b'_reversed')
 
+def unreverse_feature(feature: Feature) -> Feature:
+    assert is_reversed_feature(feature), f"Not a reversed feature: {feature!r}"
+    return Feature(feature[:-len(b'_reversed')])
 
 def check_feature(feature: Feature) -> None:
     assert isinstance(feature, bytes), f"Feature must be a bytestring: {feature!r}"


### PR DESCRIPTION
For queries containing only suffix expressions, the output shows "undefined" as words. The words (features) are also now shown in the result from search_cmdline.py. The root cause lies in the logic for selecting which features to show, which has a proposed fix in this commit.

<img width="1005" height="436" alt="Screenshot 2026-07-06 140538" src="https://github.com/user-attachments/assets/8086ab3c-f3e5-4d02-9e2b-c15384e5d73b" />
<img width="1003" height="457" alt="Screenshot 2026-07-06 140555" src="https://github.com/user-attachments/assets/dfbd848a-bd66-4dfe-9034-d45442a0ccf4" />
<img width="1007" height="270" alt="Screenshot 2026-07-06 140737" src="https://github.com/user-attachments/assets/65d85595-db9e-49a7-800d-29f4e63c5421" />
